### PR TITLE
added loading to the page title and redirect to /my-posts when is use…

### DIFF
--- a/src/pages/SomeonesPosts/index.jsx
+++ b/src/pages/SomeonesPosts/index.jsx
@@ -8,60 +8,71 @@ import Header from '../shared/Header';
 import CirclesLoader from '../shared/CirclesLoader';
 import HashtagTrending from '../shared/HashtagTrending';
 import NoPostMessage from '../shared/NoPostMessage';
-import { useParams } from 'react-router-dom';
+import { useParams, useHistory } from 'react-router-dom';
 
 
-export default function SomeonesPosts(){
+export default function SomeonesPosts() {
 	const [postsList, setPostsList] = useState([]);
 	const [userName, setUserName] = useState('');
 	const [loaderIsActive, setLoaderIsActive] = useState(false);
-	const {userInfo} = useContext(UserContext);
+	const { userInfo } = useContext(UserContext);
 	const params = useParams();
-	const {id:someonesId} = params;
+	const { id: someonesId } = params;
+	window.scrollTo(0, 0);
+	const history = useHistory();
 
-	function loadPosts(){		
+	const loadPosts = () => {
 		setLoaderIsActive(true);
-		if(userInfo.token){
-			getSomeonesPosts(someonesId ,userInfo.token).then((res)=>{
+		if (userInfo.token) {
+			getSomeonesPosts(someonesId, userInfo.token).then((res) => {
 				setUserName(res.data.posts[0].user.username);
+				if (res.data.posts[0].user.id === userInfo.userId) //check if is user's posts
+					history.push('/my-posts');
 				setPostsList(res.data.posts);
-			}).catch(()=>{
-				
+			}).catch(() => {
+
 				pageReloadErrorAlert();
-			}).finally(()=>{
+			}).finally(() => {
 				setLoaderIsActive(false);
 			});
 		}
-	}
-	
-	useEffect(()=>{		
-		loadPosts();
-	},[userInfo]);
+	};
 
-	return(
-		<>	
-			<Header/>
+	useEffect(() => {
+		loadPosts();
+	}, [userInfo]);
+
+	return (
+		<>
+			<Header />
 			<Background>
 				<TimelineContent>
-					<h1>{`${userName}'s posts`}</h1>
-					{loaderIsActive 
-						? <CirclesLoader/>
-						: (postsList.length)
-							?  postsList.map((p)=>{
+					{loaderIsActive ?
+						<h1>Carregando...</h1>
+						:
+						<h1>{`${userName}'s posts`}</h1>
+					}
+
+					{loaderIsActive? 
+						<CirclesLoader />
+						: 
+						(postsList.length)? 
+							postsList.map((p) => {
 								return (
 									<Post key={p.id} postInfo={p} />
 								);
 							})
-							: <NoPostMessage/>
+							: 
+							<NoPostMessage />
 					}
 				</TimelineContent>
 				<HashtagContainer>
-					{userInfo.token?
-						<HashtagTrending/>
+					{userInfo.token ?
+						<HashtagTrending />
 						:
 						<></>
 					}
-					
+
 				</HashtagContainer>
 			</Background>
 		</>

--- a/src/pages/shared/HashtagTrending.jsx
+++ b/src/pages/shared/HashtagTrending.jsx
@@ -15,7 +15,7 @@ export default function HashtagTrending(){
 		getHashtagTrending(token)
 			.then(({ data: { hashtags }}) => setHashtagList(hashtags))
 			.catch(loadingTrendingError);
-	}, []);
+	}, [token]);
 
 	const loadingTrendingError = () => {
 		Swal.fire({


### PR DESCRIPTION
Adicionei esses detalhes:
-Agora o titulo da página só é carregado após o carregamento do nome do perfil.
-Se o perfil clicado for o do próprio usuário, será redirecionado para a página /my-posts.
-Quando o usuário entrar para ver os posts de um perfil, a rolagem da página começa do topo.
-A única alteração feita no arquivo hastagTrending foi adicionar a variavel 'token' ao array de userEffect() para eliminar um erro. Conversei com o Tiago ontem e ele já vai fazer essa alteração no arquivo em seu proximo merge. 